### PR TITLE
Verify returned KeyId in AwsKmsAead::Decrypt (Java parity)

### DIFF
--- a/tink/integration/awskms/aws_kms_aead.cc
+++ b/tink/integration/awskms/aws_kms_aead.cc
@@ -16,6 +16,8 @@
 
 #include "tink/integration/awskms/aws_kms_aead.h"
 
+#include <vector>
+
 #include "aws/core/auth/AWSCredentialsProvider.h"
 #include "aws/core/client/AWSClient.h"
 #include "aws/core/utils/Outcome.h"
@@ -30,6 +32,7 @@
 #include "absl/strings/escaping.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
+#include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
 #include "tink/aead.h"
 #include "tink/util/status.h"
@@ -44,6 +47,14 @@ namespace {
 std::string AwsErrorToString(Aws::Client::AWSError<Aws::KMS::KMSErrors> err) {
   return absl::StrCat("AWS error code: ", err.GetErrorType(), ", ",
                       err.GetExceptionName(), ": ", err.GetMessage());
+}
+
+// IsKeyArnFormat returns true if `key_arn` is in key ARN format
+// (arn:<partition>:kms:<region>:<account>:key/<key-id>). The check is the C++
+// equivalent of tink-java-awskms `AwsKmsAead.isKeyArnFormat`.
+bool IsKeyArnFormat(absl::string_view key_arn) {
+  std::vector<absl::string_view> tokens = absl::StrSplit(key_arn, ':');
+  return tokens.size() == 6 && absl::StartsWith(tokens[5], "key/");
 }
 
 }  // namespace
@@ -106,6 +117,17 @@ util::StatusOr<std::string> AwsKmsAead::Decrypt(
     return util::Status(absl::StatusCode::kInvalidArgument,
                         absl::StrCat("AWS KMS decryption failed with error: ",
                                      AwsErrorToString(err)));
+  }
+  // Verify the returned KeyId matches the configured one. If we don't do this,
+  // the possibility exists for the ciphertext to be replaced by one under a key
+  // we don't control/expect, but do have decrypt permissions on. The check is
+  // skipped if key_arn_ is not in key ARN format, matching the behavior of the
+  // Java SDK (AwsKmsAead.java:92).
+  // See https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id.
+  if (IsKeyArnFormat(key_arn_) &&
+      outcome.GetResult().GetKeyId() != key_arn_) {
+    return util::Status(absl::StatusCode::kInvalidArgument,
+                        "AWS KMS decryption failed: wrong key id");
   }
   auto& buffer = outcome.GetResult().GetPlaintext();
   std::string plaintext(


### PR DESCRIPTION
## Summary
Tink-Java's `AwsKmsAead.decrypt` (AwsKmsAead.java:92) explicitly rejects ciphertexts where the AWS KMS response's `KeyId` does not match the configured key ARN, with this security comment:

> *"It is important to check the returned KeyId against the one previously configured. If we don't do this, the possibility exists for the ciphertext to be replaced by one under a key we don't control/expect, but do have decrypt permissions on."*

The C++ port is missing the same defense. This PR brings it to parity.

## Threat model (per Java comment)
A caller with `kms:Decrypt` permission on more than one KMS key (target key + attacker-controlled key) can be tricked into decrypting an attacker-supplied ciphertext under the attacker's key, while the application believed it was decrypting under its configured key. The application then uses the resulting plaintext as if the original ciphertext owner had blessed it.

AWS server-side enforcement isn't always sufficient by itself — Tink-Java explicitly added the client-side check anyway, with a documented rationale.

## Behavior
- When `key_arn_` is in **key ARN format** (`arn:<partition>:kms:<region>:<account>:key/<id>`) and the response's `KeyId` differs, `Decrypt` returns `kInvalidArgument` with `"AWS KMS decryption failed: wrong key id"`.
- When `key_arn_` is **not** in key ARN format (plain key id, `alias/<name>`, or alias ARN), the check is skipped — matching Java's behavior to avoid false rejections for callers that use aliases (where AWS may return the underlying key ARN, not the alias).

The new `IsKeyArnFormat` helper in the anonymous namespace is the C++ equivalent of Tink-Java's `AwsKmsAead.isKeyArnFormat`.

## Sibling work
- Java implementation: `tink-java-awskms` `AwsKmsAead.java:92` (existing — the reference)
- Go counterpart: tink-crypto/tink-go-awskms#12 (filed today)

## Reference
- AWS KMS Decrypt API returns `KeyId` in the response: https://docs.aws.amazon.com/kms/latest/APIReference/API_Decrypt.html